### PR TITLE
Remove a lot of ASM from fmath_base.h

### DIFF
--- a/kernel/arch/dreamcast/include/dc/fmath_base.h
+++ b/kernel/arch/dreamcast/include/dc/fmath_base.h
@@ -32,105 +32,24 @@ __BEGIN_DECLS
 #define F_PI 3.1415926f
 
 /** \cond */
-#define __fsin(x) \
-    ({ float __value, __arg = (x), __scale = 10430.37835f; \
-        __asm__("fmul   %2,%1\n\t" \
-                "ftrc   %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fmov   fr0,%0" \
-                : "=f" (__value), "+&f" (__scale) \
-                : "f" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
-
-#define __fcos(x) \
-    ({ float __value, __arg = (x), __scale = 10430.37835f; \
-        __asm__("fmul   %2,%1\n\t" \
-                "ftrc   %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fmov   fr1,%0" \
-                : "=f" (__value), "+&f" (__scale) \
-                : "f" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
-
-#define __ftan(x) \
-    ({ float __value, __arg = (x), __scale = 10430.37835f; \
-        __asm__("fmul   %2,%1\n\t" \
-                "ftrc   %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fdiv   fr1, fr0\n\t" \
-                "fmov   fr0,%0" \
-                : "=f" (__value), "+&f" (__scale) \
-                : "f" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
-
-
-#define __fisin(x) \
-    ({ float __value, __arg = (x); \
-        __asm__("lds    %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fmov   fr0,%0" \
-                : "=f" (__value) \
-                : "r" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
-
-#define __ficos(x) \
-    ({ float __value, __arg = (x); \
-        __asm__("lds    %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fmov   fr1,%0" \
-                : "=f" (__value) \
-                : "r" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
-
-#define __fitan(x) \
-    ({ float __value, __arg = (x); \
-        __asm__("lds    %1,fpul\n\t" \
-                "fsca   fpul,dr0\n\t" \
-                "fdiv   fr1, fr0\n\t" \
-                "fmov   fr0,%0" \
-                : "=f" (__value) \
-                : "r" (__arg) \
-                : "fpul", "fr0", "fr1"); \
-        __value; })
-
-#define __fsincos(r, s, c) \
-    ({  register float __r __asm__("fr10") = r; \
-        register float __a __asm__("fr11") = 182.04444443f; \
-        __asm__("fmul fr11, fr10\n\t" \
-                "ftrc fr10, fpul\n\t" \
-                "fsca fpul, dr10\n\t" \
-                : "+f" (__r), "+f" (__a) \
-                : "0" (__r), "1" (__a) \
-                : "fpul"); \
-        s = __r; c = __a; })
+#define __fsin(x) __builtin_sinf(x)
+#define __fcos(x) __builtin_cosf(x)
+#define __ftan(x) __builtin_tanf(x)
+#define __fisin(x) __builtin_sinf((float)(x) / 10430.37835f);
+#define __ficos(x) __builtin_cosf((float)(x) / 10430.37835f);
+#define __fitan(x) __builtin_tanf((float)(x) / 10430.37835f);
 
 #define __fsincosr(r, s, c) \
-    ({  register float __r __asm__("fr10") = r; \
-        register float __a __asm__("fr11") = 10430.37835f; \
-        __asm__("fmul fr11, fr10\n\t" \
-                "ftrc fr10, fpul\n\t" \
-                "fsca fpul, dr10\n\t" \
-                : "+f" (__r), "+f" (__a) \
-                : "0" (__r), "1" (__a) \
-                : "fpul"); \
-        s = __r; c = __a; })
+    ({  float __r = (r) / 10430.37835f; \
+        s = __fsin(__r); \
+        c = __fcos(__r); \
+    })
 
-#define __fsqrt(x) \
-    ({ float __arg = (x); \
-        __asm__("fsqrt %0\n\t" \
-                : "=f" (__arg) : "0" (__arg)); \
-        __arg; })
+#define __fsincos(r, s, c) \
+    __fsincosr((r) * 182.04444443f, s, c)
 
-#define __frsqrt(x) \
-    ({ float __arg = (x); \
-        __asm__("fsrra %0\n\t" \
-                : "=f" (__arg) : "0" (__arg)); \
-        __arg; })
+#define __fsqrt(x) __builtin_sqrtf(x)
+#define __frsqrt(x) (1.0f / __builtin_sqrtf(x))
 
 /* Floating point inner product (dot product) */
 #define __fipr(x, y, z, w, a, b, c, d) ({ \

--- a/utils/dc-chain/doc/debian.md
+++ b/utils/dc-chain/doc/debian.md
@@ -88,3 +88,5 @@ After following this guide, the toolchains should be ready.
 Now it's time to compile **KallistiOS**.
 
 You may consult the [`README`](../../../doc/README.md) file from KallistiOS now.
+
+Test


### PR DESCRIPTION
Use the compiler's built-in functions to provide __fsin(), __fcos(), __ftan(), __fisin(), __ficos(), __fitan(), __fsincosr(), __fsincos(), __fsqrt() and __fsqrtr().

The same code (or better) will be generated as long as the -mfsrra and -mfsca flags are passed.

The exception is __fsincos() which generates slightly worse code because of a missed optimization in GCC.